### PR TITLE
Fix a bug with `input_video` being undefined

### DIFF
--- a/inference_codeformer.py
+++ b/inference_codeformer.py
@@ -72,6 +72,7 @@ if __name__ == '__main__':
 
     # ------------------------ input & output ------------------------
     w = args.w
+    input_video = False
 
     if args.test_path.endswith(('jpg', 'png')): # input single img path
         input_img_list = [args.test_path]


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/notebooks/__includes/vendored/codeformer/inference_codeformer.py", line 237, in <module>
    if input_video:
NameError: name 'input_video' is not defined
```