### PR TITLE
Replaced PyTorch version check with regex.

### DIFF
--- a/facelib/detection/yolov5face/face_detector.py
+++ b/facelib/detection/yolov5face/face_detector.py
@@ -1,6 +1,7 @@
 import copy
 import os
 from pathlib import Path
+import re
 
 import cv2
 import numpy as np
@@ -17,7 +18,7 @@ from facelib.detection.yolov5face.utils.general import (
     scale_coords_landmarks,
 )
 
-IS_HIGH_VERSION = tuple(map(int, torch.__version__.split('+')[0].split('.')[:3])) >= (1, 9, 0)
+IS_HIGH_VERSION = [int(m) for m in list(re.findall(r"^([0-9]+)\.([0-9]+)\.([0-9]+)([^0-9][a-zA-Z0-9]*)?(\+git.*)?$", torch.__version__)[0][:3])] >= [1, 9, 0]
 
 
 def isListempty(inList):


### PR DESCRIPTION
This makes it able to handle non-compliant version schemes like 1.13.0a0 which are present in the pre-releases of PyTorch.

This is [an issue multiple people are currently suffering from](https://github.com/l1na-forever/stable-diffusion-rocm-docker/issues/9).