### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 addict
 future
+gradio
 lmdb
 numpy
 opencv-python


### PR DESCRIPTION
After running:

\CodeFormer>` pip install -r .\requirements.txt`

there was this when trying to run **python app.py**:```

\CodeFormer\app.py", line 12, in <module>
    import gradio as gr
ModuleNotFoundError: No module named 'gradio'
```