### PR TITLE
fix: use regexp to extract pytorch version in misc.py

### DIFF
--- a/basicsr/utils/misc.py
+++ b/basicsr/utils/misc.py
@@ -9,7 +9,7 @@ from os import path as osp
 from .dist_util import master_only
 from .logger import get_root_logger
 
-IS_HIGH_VERSION = [int(m) for m in list(re.findall(r"^([0-9]+)\.([0-9]+)\.([0-9]+)([^0-9][a-zA-Z0-9]*)?(\+git.*)?$",\
+IS_HIGH_VERSION = [int(m) for m in list(re.findall(r"^(\d+)\.(\d+)\.(\d+)([\w\d\.].*)?$",\
     torch.__version__)[0][:3])] >= [1, 12, 0]
 
 def gpu_is_available():


### PR DESCRIPTION
I've test above version, all cases are passed:

```python
1.0.0
2.1.2
1.0.0a1
1.0.0a1+git
2.1.0.dev20230728+cu121
2.1.0a0+b5021ba
2.0.0.dev20230219+cu118
```

online review link: https://regex101.com/r/pfxFFI/1


