### PR TITLE
[FIXED] UnboundLocalError: local variable 'output_tile' referenced before assignment

### DIFF
--- a/basicsr/utils/realesrgan_utils.py
+++ b/basicsr/utils/realesrgan_utils.py
@@ -143,6 +143,7 @@ class RealESRGANer():
                         output_tile = self.model(input_tile)
                 except RuntimeError as error:
                     print('Error', error)
+                    raise RuntimeError(error)
                 # print(f'\tTile {tile_idx}/{tiles_x * tiles_y}')
 
                 # output tile area on total image


### PR DESCRIPTION
## Fixes

- fix: if get output_tile failed, raise an error