### PR TITLE
fix: dependencies fix(Pillow==9.5.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future
 lmdb
 numpy
 opencv-python
-Pillow
+Pillow==9.5.0
 pyyaml
 requests
 scikit-image


### PR DESCRIPTION
resolve error: AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
use Pillow version: 9.5.0
the later versions remove it
![image](https://github.com/sczhou/CodeFormer/assets/25458528/4da6eecc-aecf-48a4-9646-d584b5ea9474)
