### PR TITLE
Ensures adain_npy returned pixel value is within the range of bit depth

### DIFF
--- a/facelib/utils/misc.py
+++ b/facelib/utils/misc.py
@@ -199,4 +199,18 @@ def adain_npy(content_feat, style_feat):
     style_mean, style_std = calc_mean_std(style_feat)
     content_mean, content_std = calc_mean_std(content_feat)
     normalized_feat = (content_feat - np.broadcast_to(content_mean, size)) / np.broadcast_to(content_std, size)
-    return normalized_feat * np.broadcast_to(style_std, size) + np.broadcast_to(style_mean, size)
+    result_feat = normalized_feat * np.broadcast_to(style_std, size) + np.broadcast_to(style_mean, size)
+
+    # Ensure values are within the range of source image bit depth
+    bit_range = 256 if np.max(content_feat) < 256 else 65536 # determine 8 bit or 16 bit.
+    a_min, a_max = np.min(result_feat, axis=(0,1)), np.max(result_feat, axis=(0,1)) # min/max of each color
+    i_min, i_max = np.argmin(a_min), np.argmax(a_max) # find the color index of global min and max
+    v_min, v_max = a_min[i_min], a_max[i_max]         # global min and max
+    if v_max > bit_range or v_min < 0:                # pixel value is out of the range of bit depth
+        # reduce the style_std to clamp values in range.
+        mean_min, mean_max = style_mean[0][0][i_min], style_mean[0][0][i_max] # mean of color for min/max
+        ratio = min(mean_min / (mean_min - v_min), (bit_range - 1e-12 - mean_max) / (v_max - mean_max))
+        style_std = style_std * np.broadcast_to([ratio, ratio, ratio], style_std.shape)
+        result_feat = normalized_feat * np.broadcast_to(style_std, size) + np.broadcast_to(style_mean, size)
+
+    return result_feat


### PR DESCRIPTION
This fixes #222. The normalization process of `adain_npy` can generate pixel values out of the range of bit depth. For example, it computed values less than 0 or greater than 256 for 8-bit images. When this happens, the later process will consider the image to be 16 bit and resulting in an entirely black image. The solution is to compute a proper ratio to reduce `style_std` so that no pixel would exceed the range of original bit depth while still apply the style in the best effort.